### PR TITLE
Add types to comply with symphony HTTPExceptionInterface

### DIFF
--- a/exceptions/JsonValidationException.php
+++ b/exceptions/JsonValidationException.php
@@ -9,12 +9,12 @@ use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 class JsonValidationException extends ValidationException implements HttpExceptionInterface
 {
-    public function getStatusCode()
+    public function getStatusCode(): int
     {
         return Response::HTTP_UNPROCESSABLE_ENTITY;
     }
 
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return [
             'Content-type' => 'application/json;charset=UTF-8'


### PR DESCRIPTION
## issue
Error message when trying to use the user related endpoints:
```
Symfony\Component\ErrorHandler\Error\FatalError: Declaration of RLuders\JWTAuth\Exceptions\JsonValidationException::getStatusCode() must be compatible with Symfony\Component\HttpKernel\Exception\HttpExceptionInterface::getStatusCode(): int in /app/code/plugins/rluders/jwtauth/exceptions/JsonValidationException.php:12
```

## fix
HTTPExceptionInterface in php 8> requires that the declaration contain types
This quick patch makes the `JsonValidationException` compatible to `Symfony\Component\HttpKernel\Exception\HttpExceptionInterface` again.
